### PR TITLE
Integrate optimize_battery package on home screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
    <uses-permission android:name="android.permission.INTERNET" />
    <uses-permission android:name="android.permission.WAKE_LOCK" />
    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+   <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
    <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
     />

--- a/lib/UI/home_page.dart
+++ b/lib/UI/home_page.dart
@@ -12,13 +12,33 @@ import 'package:podboi/UI/podcast_page.dart';
 import 'package:podboi/UI/profile_page.dart';
 import 'package:podboi/UI/search_page.dart';
 import 'package:podcast_search/podcast_search.dart';
+import 'package:optimize_battery/optimize_battery.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   HomePage({Key? key, required this.ref}) : super(key: key);
   final WidgetRef ref;
 
+  @override
+  _HomePageState createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
   Future<void> _refresh() async {
-    ref.read(homeScreenController.notifier).getTopPodcasts();
+    widget.ref.read(homeScreenController.notifier).getTopPodcasts();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _checkBatteryOptimization();
+  }
+
+  Future<void> _checkBatteryOptimization() async {
+    bool isIgnoringBatteryOptimizations =
+        await OptimizeBattery.isIgnoringBatteryOptimizations();
+    if (!isIgnoringBatteryOptimizations && mounted) {
+      OptimizeBattery.stopOptimizingBatteryUsage();
+    }
   }
 
   @override
@@ -44,10 +64,10 @@ class HomePage extends StatelessWidget {
               child: CustomScrollView(
                 slivers: [
                   SliverToBoxAdapter(
-                    child: buildTopUi(context),
+                    child: _buildTopUi(context),
                   ),
                   SliverToBoxAdapter(
-                    child: buildSearchRow(context),
+                    child: _buildSearchRow(context),
                   ),
                   SliverToBoxAdapter(
                     child: Padding(
@@ -83,7 +103,7 @@ class HomePage extends StatelessWidget {
                       ),
                     ),
                   ),
-                  buildDiscoverPodcastsRow(context),
+                  _buildDiscoverPodcastsRow(context),
                 ],
               ),
             ),
@@ -93,7 +113,7 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  Padding buildSearchRow(BuildContext context) {
+  Padding _buildSearchRow(BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(
         top: 18.0,
@@ -158,14 +178,14 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  Widget buildDiscoverPodcastsRow(BuildContext context) {
+  Widget _buildDiscoverPodcastsRow(BuildContext context) {
     return Consumer(
       builder: (context, ref, child) {
-        List<Item> _topPodcasts = ref.watch(
+        List<Item> _topPodcasts = widget.ref.watch(
           homeScreenController.select((value) => value.topPodcasts),
         );
         bool _isLoading =
-            ref.watch(homeScreenController.select((value) => value.isLoading));
+            widget.ref.watch(homeScreenController.select((value) => value.isLoading));
         return _isLoading
             ? SliverToBoxAdapter(
                 child: Container(
@@ -261,18 +281,18 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  Column buildTopUi(BuildContext context) {
+  Column _buildTopUi(BuildContext context) {
     return Column(
       children: [
         SizedBox(
           height: 16.0,
         ),
         Consumer(builder: (context, ref, child) {
-          String _name = ref.watch(
+          String _name = widget.ref.watch(
             profileController.select((value) => value.userName),
           );
           String _avatar =
-              ref.watch(profileController.select((value) => value.userAvatar));
+              widget.ref.watch(profileController.select((value) => value.userAvatar));
           return Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/UI/home_page.dart
+++ b/lib/UI/home_page.dart
@@ -12,7 +12,7 @@ import 'package:podboi/UI/podcast_page.dart';
 import 'package:podboi/UI/profile_page.dart';
 import 'package:podboi/UI/search_page.dart';
 import 'package:podcast_search/podcast_search.dart';
-import 'package:optimize_battery/optimize_battery.dart';
+import 'package:battery_optimizer/battery_optimizer.dart';
 
 class HomePage extends StatefulWidget {
   HomePage({Key? key, required this.ref}) : super(key: key);
@@ -34,10 +34,10 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _checkBatteryOptimization() async {
-    bool isIgnoringBatteryOptimizations =
-        await OptimizeBattery.isIgnoringBatteryOptimizations();
-    if (!isIgnoringBatteryOptimizations && mounted) {
-      OptimizeBattery.stopOptimizingBatteryUsage();
+    bool isBatteryOptimizationEnabled =
+        await BatteryOptimizer.isBatteryOptimizationEnabled();
+    if (isBatteryOptimizationEnabled && mounted) {
+      BatteryOptimizer.requestDisableBatteryOptimization();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   podcast_search: ^0.7.4
   riverpod_annotation: ^2.6.1
   rxdart: ^0.28.0
+  optimize_battery: ^0.0.4
 
 dev_dependencies:
   build_runner: ^2.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   podcast_search: ^0.7.4
   riverpod_annotation: ^2.6.1
   rxdart: ^0.28.0
-  optimize_battery: ^0.0.4
+  battery_optimizer: ^0.0.2
 
 dev_dependencies:
   build_runner: ^2.2.1


### PR DESCRIPTION
This change integrates the `optimize_battery` package to allow the app to request exemption from battery optimizations. This is intended to prevent audio playback from being interrupted by the OS.

The battery optimization check is now performed when you reach the home screen, instead of at app startup.

The following changes were made:
- Added `optimize_battery: ^0.0.4` to `pubspec.yaml`.
- Added `android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission to `AndroidManifest.xml`.
- Removed battery optimization check from `lib/main.dart`.
- Modified `lib/UI/home_page.dart` to check if the app is ignoring battery optimizations and, if not, prompts you to disable optimization for the app when the home page is initialized.