### PR TITLE
Feat: Handle miniplayer errors with retry

### DIFF
--- a/lib/Controllers/audio_controller.dart
+++ b/lib/Controllers/audio_controller.dart
@@ -202,6 +202,10 @@ class AudioStateNotifier extends StateNotifier<AudioState> {
       return (state as LoadedAudioState).currentPlaying;
     } else if (state is LoadingAudioState) {
       return (state as LoadingAudioState).song;
+    } else if (state is ErrorAudioState) {
+      if ((state as ErrorAudioState).song != null) {
+        return (state as ErrorAudioState).song;
+      }
     }
 
     return null;
@@ -337,7 +341,11 @@ class AudioStateNotifier extends StateNotifier<AudioState> {
       // Catch load errors: 404, invalid url ...
       print("Error loading playlist: $e");
       print(stackTrace);
-      state = ErrorAudioState(errorMessage: e.toString(), playlist: _playlist);
+      state = ErrorAudioState(
+        errorMessage: e.toString(),
+        playlist: _playlist,
+        song: song,
+      );
     }
   }
 
@@ -468,8 +476,10 @@ class LoadingAudioState extends AudioState {
 
 class ErrorAudioState extends AudioState {
   String errorMessage;
+  Song? song;
 
-  ErrorAudioState({required this.errorMessage, required super.playlist});
+  ErrorAudioState(
+      {required this.errorMessage, required super.playlist, this.song});
 }
 
 class LoadedAudioState extends AudioState {

--- a/lib/UI/player/large_player.dart
+++ b/lib/UI/player/large_player.dart
@@ -41,7 +41,27 @@ class _LargePlayerState extends State<LargePlayer> {
 
             List<Song> playlist = ref.watch(audioController).playlist;
 
-            if (state is! LoadedAudioState && state is! LoadingAudioState)
+            if (state is ErrorAudioState) {
+              return Column(
+                children: [
+                  LargePlayerAlbumArtWidget(
+                    song: (ref.read(audioController.notifier).getCurrentPlayingSong)!,
+                  ),
+                  SizedBox(height: 12.0),
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    iconSize: 64.0,
+                    onPressed: () {
+                      ref.read(audioController.notifier).requestPlayingSong(
+                            (ref.read(audioController.notifier).getCurrentPlayingSong)!,
+                          );
+                    },
+                  ),
+                ],
+              );
+            }
+
+            if (state is! LoadedAudioState && state is! LoadingAudioState) {
               return Container(
                 decoration: BoxDecoration(
                   color: Theme.of(context).highlightColor.withOpacityValue(0.1),
@@ -57,7 +77,7 @@ class _LargePlayerState extends State<LargePlayer> {
                   strokeWidth: 2.0,
                 ),
               );
-
+            }
             late Song song;
             AudioPlayer? player;
 

--- a/lib/UI/player/mini_player.dart
+++ b/lib/UI/player/mini_player.dart
@@ -43,8 +43,10 @@ class _MiniPlayerState extends State<MiniPlayer> {
 
           // Error state.
           else if (_contState is ErrorAudioState) {
-            return Container(
-              child: Text(" Error: ${_contState.errorMessage}"),
+            return buildSmallPlayer(
+              _contState,
+              ref,
+              isError: true,
             );
           }
 
@@ -70,8 +72,14 @@ class _MiniPlayerState extends State<MiniPlayer> {
   }
 
   /// SmallPlayer Widget. Height is restricted to `_smallPlayerHeight`
-  Widget buildSmallPlayer(AudioState _contState, WidgetRef ref) {
-    if (_contState is! LoadingAudioState && _contState is! LoadedAudioState) {
+  Widget buildSmallPlayer(
+    AudioState _contState,
+    WidgetRef ref, {
+    bool isError = false,
+  }) {
+    if (_contState is! LoadingAudioState &&
+        _contState is! LoadedAudioState &&
+        _contState is! ErrorAudioState) {
       return Container();
     }
 
@@ -80,6 +88,8 @@ class _MiniPlayerState extends State<MiniPlayer> {
       song = _contState.song;
     } else if (_contState is LoadedAudioState) {
       song = _contState.currentPlaying;
+    } else if (_contState is ErrorAudioState) {
+      song = (ref.read(audioController.notifier).getCurrentPlayingSong)!;
     }
 
     return Material(
@@ -152,12 +162,23 @@ class _MiniPlayerState extends State<MiniPlayer> {
                 if (_contState is LoadingAudioState)
                   MiniplayerLoadingIndicator(),
 
-                if (_contState is LoadedAudioState)
+                if (_contState is LoadedAudioState && !isError)
                   MiniplayerActionButtons(
                     state: _contState,
                     ref: ref,
                   ),
 
+                // Retry button.
+                if (isError)
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    iconSize: 34.0,
+                    onPressed: () {
+                      ref
+                          .read(audioController.notifier)
+                          .requestPlayingSong(song);
+                    },
+                  ),
                 const SizedBox(width: 8.0),
               ],
             ),


### PR DESCRIPTION
This commit implements error handling for the miniplayer.

When an error occurs during audio playback, the miniplayer will now display the podcast details along with a retry button. This provides a better user experience than simply showing an error message.

Changes:
- Modified `mini_player.dart` to display a retry button in the error state.
- Updated `audio_controller.dart` to provide the failed song to the UI and to handle the retry logic.